### PR TITLE
perf(core/options) added scope of the icon sources package

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,27 @@ Icons({
 
 It will install the icon set when you import them. The right package manager will be auto-detected (`npm`, `yarn` or `pnpm`).
 
+###### Install from custom  `scope`
+
+If you need to use icons from a third party package other than `@iconify-json`, you can specify `scope` 
+
+```ts
+Icons({
+  scope: '@my-scope',
+})
+```
+> `@my-scope` is the package name of the package that contains the icons. Your package must follow the [iconifyIcon type](https://iconify.design/docs/types/iconify-icon.html) specification.
+
+Combined with `autoInstall`, your icons will be loaded from the `scope` you specify.
+
+```ts
+Icons({
+  scope: '@my-scope',
+  autoInstall: true,
+})
+```
+
+
 ## Examples
 
 You can play online with the examples in this repo in StackBlitz, see [playgrounds page](./examples/README.md).
@@ -315,7 +336,7 @@ export default {
         compiler: 'jsx',
         jsx: 'react'
       })
-    )        
+    )
 
     return config
   }

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
   "dependencies": {
     "@antfu/install-pkg": "^0.3.0",
     "@antfu/utils": "^0.7.6",
-    "@iconify/utils": "^2.1.12",
+    "@iconify/utils": "^2.1.17",
     "debug": "^4.3.4",
     "kolorist": "^1.8.0",
     "local-pkg": "^0.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.7.6
         version: 0.7.6
       '@iconify/utils':
-        specifier: ^2.1.12
-        version: 2.1.12
+        specifier: ^2.1.17
+        version: 2.1.17
       debug:
         specifier: ^4.3.4
         version: 4.3.4
@@ -3281,15 +3281,15 @@ packages:
   /@iconify/types@2.0.0:
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  /@iconify/utils@2.1.12:
-    resolution: {integrity: sha512-7vf3Uk6H7TKX4QMs2gbg5KR1X9J0NJzKSRNWhMZ+PWN92l0t6Q3tj2ZxLDG07rC3ppWBtTtA4FPmkQphuEmdsg==}
+  /@iconify/utils@2.1.17:
+    resolution: {integrity: sha512-YSzYJwMsCUq1kayUqhQnmJ8mrz4R+CZp/nwc68CEEgWG20eqDplAwyIHKVAzrIRUBzgfgYkGgJSs/z+RaKkKtw==}
     dependencies:
       '@antfu/install-pkg': 0.1.1
       '@antfu/utils': 0.7.6
       '@iconify/types': 2.0.0
       debug: 4.3.4
       kolorist: 1.8.0
-      local-pkg: 0.4.3
+      local-pkg: 0.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -10223,6 +10223,7 @@ packages:
   /local-pkg@0.4.3:
     resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
     engines: {node: '>=14'}
+    dev: true
 
   /local-pkg@0.5.0:
     resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}

--- a/src/core/loader.ts
+++ b/src/core/loader.ts
@@ -63,12 +63,14 @@ export async function generateComponent({ collection, icon, query }: ResolvedIco
     iconCustomizer: providedIconCustomizer,
     transform,
     autoInstall = false,
+    scope,
   } = options
   const iconifyLoaderOptions: IconifyLoaderOptions = {
     addXmlNs: false,
     scale,
     customCollections,
     autoInstall,
+    scope,
     defaultClass,
     defaultStyle,
     // there is no need to warn since we throw an error below

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -15,6 +15,7 @@ export async function resolveOptions(options: Options): Promise<ResolvedOptions>
     iconCustomizer = () => {},
     transform,
     autoInstall = false,
+    scope,
   } = options
 
   const webComponents = Object.assign({
@@ -35,6 +36,7 @@ export async function resolveOptions(options: Options): Promise<ResolvedOptions>
     webComponents,
     transform,
     autoInstall,
+    scope,
   }
 }
 
@@ -53,7 +55,7 @@ async function getVueVersion() {
     const result = await getPackageInfo('vue')
     if (!result)
       return null
-    return result.version.startsWith('2.') ? 'vue2' : 'vue3'
+    return result.version?.startsWith('2.') ? 'vue2' : 'vue3'
   }
   catch {
     return null

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,13 @@ export interface Options {
   autoInstall?: boolean
 
   /**
+   * The scope of the icon sources package
+   *
+   * @default '@iconify-json'
+   */
+  scope?: string
+
+  /**
    * Compiler
    *
    * - none: plain SVG content
@@ -103,4 +110,4 @@ export interface Options {
   iconSource?: 'legacy' | 'modern' | 'auto'
 }
 
-export type ResolvedOptions = Omit<Required<Options>, 'iconSource' | 'transform'> & Pick<Options, 'transform'>
+export type ResolvedOptions = Omit<Required<Options>, 'iconSource' | 'transform' | 'scope'> & Pick<Options, 'transform' | 'scope'>

--- a/test/__snapshots__/idSvg.test.ts.snap
+++ b/test/__snapshots__/idSvg.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`handleSVGId 1`] = `
 {
@@ -6,41 +6,41 @@ exports[`handleSVGId 1`] = `
   "injectScripts": "const __randId = () => Math.random().toString(36).substr(2, 10);const idMap = {'ssvg-id-vitejsa':'uicons-'+__randId(),'ssvg-id-vitejsb':'uicons-'+__randId()};",
   "svg": "
 <svg
-  width=\\"1.2em\\"
-  height=\\"1.2em\\"
-  preserveAspectRatio=\\"xMidYMid meet\\"
-  viewBox=\\"0 0 256 257\\"
+  width="1.2em"
+  height="1.2em"
+  preserveAspectRatio="xMidYMid meet"
+  viewBox="0 0 256 257"
 >
   <defs>
     <linearGradient
-      x1=\\"-.828%\\"
-      y1=\\"7.652%\\"
-      x2=\\"57.636%\\"
-      y2=\\"78.411%\\"
-      :id=\\"idMap['ssvg-id-vitejsa']\\"
+      x1="-.828%"
+      y1="7.652%"
+      x2="57.636%"
+      y2="78.411%"
+      :id="idMap['ssvg-id-vitejsa']"
     >
-      <stop stop-color=\\"#41D1FF\\" offset=\\"0%\\"></stop>
-      <stop stop-color=\\"#BD34FE\\" offset=\\"100%\\"></stop>
+      <stop stop-color="#41D1FF" offset="0%"></stop>
+      <stop stop-color="#BD34FE" offset="100%"></stop>
     </linearGradient>
     <linearGradient
-      x1=\\"43.376%\\"
-      y1=\\"2.242%\\"
-      x2=\\"50.316%\\"
-      y2=\\"89.03%\\"
-      :id=\\"idMap['ssvg-id-vitejsb']\\"
+      x1="43.376%"
+      y1="2.242%"
+      x2="50.316%"
+      y2="89.03%"
+      :id="idMap['ssvg-id-vitejsb']"
     >
-      <stop stop-color=\\"#FFEA83\\" offset=\\"0%\\"></stop>
-      <stop stop-color=\\"#FFDD35\\" offset=\\"8.333%\\"></stop>
-      <stop stop-color=\\"#FFA800\\" offset=\\"100%\\"></stop>
+      <stop stop-color="#FFEA83" offset="0%"></stop>
+      <stop stop-color="#FFDD35" offset="8.333%"></stop>
+      <stop stop-color="#FFA800" offset="100%"></stop>
     </linearGradient>
   </defs>
   <path
-    d=\\"M255.153 37.938L134.897 252.976c-2.483 4.44-8.862 4.466-11.382.048L.875 37.958c-2.746-4.814 1.371-10.646 6.827-9.67l120.385 21.517a6.537 6.537 0 0 0 2.322-.004l117.867-21.483c5.438-.991 9.574 4.796 6.877 9.62z\\"
-    :fill=\\"'url(#'+idMap['ssvg-id-vitejsa']+')'\\"
+    d="M255.153 37.938L134.897 252.976c-2.483 4.44-8.862 4.466-11.382.048L.875 37.958c-2.746-4.814 1.371-10.646 6.827-9.67l120.385 21.517a6.537 6.537 0 0 0 2.322-.004l117.867-21.483c5.438-.991 9.574 4.796 6.877 9.62z"
+    :fill="'url(#'+idMap['ssvg-id-vitejsa']+')'"
   ></path>
   <path
-    d=\\"M185.432.063L96.44 17.501a3.268 3.268 0 0 0-2.634 3.014l-5.474 92.456a3.268 3.268 0 0 0 3.997 3.378l24.777-5.718c2.318-.535 4.413 1.507 3.936 3.838l-7.361 36.047c-.495 2.426 1.782 4.5 4.151 3.78l15.304-4.649c2.372-.72 4.652 1.36 4.15 3.788l-11.698 56.621c-.732 3.542 3.979 5.473 5.943 2.437l1.313-2.028l72.516-144.72c1.215-2.423-.88-5.186-3.54-4.672l-25.505 4.922c-2.396.462-4.435-1.77-3.759-4.114l16.646-57.705c.677-2.35-1.37-4.583-3.769-4.113z\\"
-    :fill=\\"'url(#'+idMap['ssvg-id-vitejsb']+')'\\"
+    d="M185.432.063L96.44 17.501a3.268 3.268 0 0 0-2.634 3.014l-5.474 92.456a3.268 3.268 0 0 0 3.997 3.378l24.777-5.718c2.318-.535 4.413 1.507 3.936 3.838l-7.361 36.047c-.495 2.426 1.782 4.5 4.151 3.78l15.304-4.649c2.372-.72 4.652 1.36 4.15 3.788l-11.698 56.621c-.732 3.542 3.979 5.473 5.943 2.437l1.313-2.028l72.516-144.72c1.215-2.423-.88-5.186-3.54-4.672l-25.505 4.922c-2.396.462-4.435-1.77-3.759-4.114l16.646-57.705c.677-2.35-1.37-4.583-3.769-4.113z"
+    :fill="'url(#'+idMap['ssvg-id-vitejsb']+')'"
   ></path>
 </svg>
 ",


### PR DESCRIPTION
### Description

This performance will make it possible to use automatic loading of icons in the package [unplugin-icons](https://github.com/unplugin/unplugin-icons) from arbitrary packages.



### Linked Issues

- https://github.com/iconify/iconify/pull/274
- https://github.com/unplugin/unplugin-icons/issues/12

### Additional context

I will be glad to receive any comments and suggestions.
