### PR TITLE
feat: custom external collection packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,16 @@ import { ExternalPackageIconLoader } from 'unplugin-icons/loaders'
 Icons({ customCollections: ExternalPackageIconLoader('my-awesome-collection') })
 ```
 
+When using with resolvers for auto-importing, remember you will need to tell it your custom collection names:
+```ts
+IconResolver({
+  customCollections: [
+    'my-awesome-collection',
+  ],
+})
+```
+
+
 You can also combine it with `FileSystemIconLoader` or with other custom icon loaders:
 ```ts
 // loader helpers
@@ -766,6 +776,8 @@ Icons({
   },
 )
 ```
+
+See the [Vue 3 + Vite example](./examples/vite-vue3/vite.config.ts).
 
 ## Icon customizer
 

--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ See the [Vue 3 + Vite example](./examples/vite-vue3/vite.config.ts).
 
 From version `v0.18.3` you can use other packages to load icons from others authors.
 
-**WARNING**: the package must include `icons.json` file with the `icons` data in `IconifyJSON` format, which can be exported with Iconify Tools. Check [Exporting icon set as JSON package](https://iconify.design/docs/libraries/tools/export/json-package.html) for more details.
+**WARNING**: external packages must include `icons.json` file with the `icons` data in `IconifyJSON` format, which can be exported with Iconify Tools. Check [Exporting icon set as JSON package](https://iconify.design/docs/libraries/tools/export/json-package.html) for more details.
 
 For example, you can use `an-awesome-collection` or `@my-awesome-collections/some-collection` to load your custom or third party icons:
 ```ts

--- a/README.md
+++ b/README.md
@@ -735,6 +735,38 @@ IconResolver({
 
 See the [Vue 3 + Vite example](./examples/vite-vue3/vite.config.ts).
 
+### Use Custom External Collection Packages
+
+From version `v0.18.3` you can use other packages to load your custom icons.
+
+**WARNING**: the package must follow
+
+For example, you can use `my-awesome-collection` or `@my-awesome-collections/some-collection` to load your custom icons:
+```ts
+// loader helpers
+import { ExternalPackageIconLoader } from 'unplugin-icons/loaders'
+
+Icons({ customCollections: ExternalPackageIconLoader('my-awesome-collection') })
+```
+
+You can also combine it with `FileSystemIconLoader` or with other custom icon loaders:
+```ts
+// loader helpers
+import { ExternalPackageIconLoader, FileSystemIconLoader } from 'unplugin-icons/loaders'
+
+Icons({ 
+  customCollections: {
+    ...ExternalPackageIconLoader('my-awesome-collection'),
+    ...ExternalPackageIconLoader('@my-awesome-collections/some-collection'),
+    ...ExternalPackageIconLoader('@my-awesome-collections/some-other-collection'),
+    'my-yet-other-icons': FileSystemIconLoader(
+      './assets/icons', 
+      svg => svg.replace(/^<svg /, '<svg fill="currentColor" '),
+    ),
+  },
+)
+```
+
 ## Icon customizer
 
 From `v0.13` you can also customize each icon using `iconCustomizer` configuration option or using query params when importing them.

--- a/README.md
+++ b/README.md
@@ -737,11 +737,11 @@ See the [Vue 3 + Vite example](./examples/vite-vue3/vite.config.ts).
 
 ### Use Custom External Collection Packages
 
-From version `v0.18.3` you can use other packages to load your custom icons.
+From version `v0.18.3` you can use other packages to load icons from others authors.
 
-**WARNING**: the package must follow
+**WARNING**: the package must include `icons.json` file with the `icons` data in `IconifyJSON` format, which can be exported with Iconify Tools. Check [Exporting icon set as JSON package](https://iconify.design/docs/libraries/tools/export/json-package.html) for more details.
 
-For example, you can use `my-awesome-collection` or `@my-awesome-collections/some-collection` to load your custom icons:
+For example, you can use `an-awesome-collection` or `@my-awesome-collections/some-collection` to load your custom or third party icons:
 ```ts
 // loader helpers
 import { ExternalPackageIconLoader } from 'unplugin-icons/loaders'
@@ -756,7 +756,7 @@ import { ExternalPackageIconLoader, FileSystemIconLoader } from 'unplugin-icons/
 
 Icons({ 
   customCollections: {
-    ...ExternalPackageIconLoader('my-awesome-collection'),
+    ...ExternalPackageIconLoader('an-awesome-collection'),
     ...ExternalPackageIconLoader('@my-awesome-collections/some-collection'),
     ...ExternalPackageIconLoader('@my-awesome-collections/some-other-collection'),
     'my-yet-other-icons': FileSystemIconLoader(

--- a/examples/vite-vue3/App.vue
+++ b/examples/vite-vue3/App.vue
@@ -5,6 +5,9 @@ import MdiAlarmOff2 from 'virtual:icons/mdi/alarm-off?width=1em&height=1em'
 import RawMdiAlarmOff from 'virtual:icons/mdi/alarm-off?raw&width=4.25rem&height=4.25rem'
 import RawMdiAlarmOff2 from 'virtual:icons/mdi/alarm-off?raw&width=1em&height=1em'
 import RawMdiAlarmOff3 from 'virtual:icons/mdi/alarm-off?raw&width=unset&height=unset'
+import Custom1 from 'virtual:icons/plain-color-icons/about?raw'
+import Custom2 from 'virtual:icons/test-color-icons/about?raw'
+import ExternalCustom3 from 'virtual:icons/test-color-icons/about'
 </script>
 
 <template>
@@ -27,6 +30,9 @@ import RawMdiAlarmOff3 from 'virtual:icons/mdi/alarm-off?raw&width=unset&height=
       <i-twemoji-1st-place-medal />
       <IIcTwotone23mp />
       <MdiStore24Hour />
+      <ExternalCustom3 />
+      <i-test-color-icons:about />
+      <i-plain-color-icons:about />
       <br>
     </p>
     <h2>Customizer via Config</h2>
@@ -79,6 +85,18 @@ import RawMdiAlarmOff3 from 'virtual:icons/mdi/alarm-off?raw&width=unset&height=
         <code style="opacity: 0.5">import RawMdiAlarmOff3 from
           'virtual:icons/mdi/alarm-off?raw&width=unset&height=unset'</code>
         <pre>{{ RawMdiAlarmOff3 }}</pre>
+      </div>
+      <span v-html="Custom1" />
+      <div>
+        <code style="opacity: 0.5">import Custom1 from
+          'virtual:icons/plain-color-icons/about?raw'</code>
+        <pre>{{ Custom1 }}</pre>
+      </div>
+      <span v-html="Custom2" />
+      <div>
+        <code style="opacity: 0.5">import Custom2 from
+          'virtual:icons/test-color-icons/about?raw'</code>
+        <pre>{{ Custom2 }}</pre>
       </div>
     </div>
     <br>

--- a/examples/vite-vue3/components.d.ts
+++ b/examples/vite-vue3/components.d.ts
@@ -26,7 +26,9 @@ declare module 'vue' {
     IMdiLightAlarm: typeof import('~icons/mdi-light/alarm')['default']
     INotoV1FlagForFlagJapan: typeof import('~icons/noto-v1/flag-for-flag-japan')['default']
     IParkAbnormal: typeof import('~icons/icon-park/abnormal')['default']
+    'IPlainColorIcons:about': typeof import('~icons/plain-color-icons/about')['default']
     IRiApps2Line: typeof import('~icons/ri/apps2-line')['default']
+    'ITestColorIcons:about': typeof import('~icons/test-color-icons/about')['default']
     ITwemoji1stPlaceMedal: typeof import('~icons/twemoji/1st-place-medal')['default']
   }
 }

--- a/examples/vite-vue3/vite.config.ts
+++ b/examples/vite-vue3/vite.config.ts
@@ -1,10 +1,24 @@
-import { promises as fs } from 'node:fs'
+import { cpSync, promises as fs } from 'node:fs'
 import type { UserConfig } from 'vite'
 import Vue from '@vitejs/plugin-vue'
 import Icons from 'unplugin-icons/vite'
-import { FileSystemIconLoader } from 'unplugin-icons/loaders'
+import { ExternalPackageIconLoader, FileSystemIconLoader } from 'unplugin-icons/loaders'
 import IconsResolver from 'unplugin-icons/resolver'
 import Components from 'unplugin-vue-components/vite'
+
+/************************************************************/
+// DON'T DO THIS IN YOUR CODE: IT IS FOR TESTING PURPOSES ONLY
+cpSync(
+  './plain-color-icons',
+  './node_modules/plain-color-icons',
+  { recursive: true },
+)
+cpSync(
+  './@test-scope',
+  './node_modules/@test-scope',
+  { recursive: true },
+)
+/************************************************************/
 
 const config: UserConfig = {
   plugins: [
@@ -12,6 +26,8 @@ const config: UserConfig = {
     Icons({
       compiler: 'vue3',
       customCollections: {
+        ...ExternalPackageIconLoader('@test-scope/test-color-icons'),
+        ...ExternalPackageIconLoader('plain-color-icons'),
         custom: FileSystemIconLoader('assets/custom-a'),
         inline: {
           foo: `
@@ -37,7 +53,13 @@ const config: UserConfig = {
           alias: {
             park: 'icon-park',
           },
-          customCollections: ['custom', 'inline'],
+          customCollections: [
+            'custom',
+            'inline',
+            // custom external packages
+            'plain-color-icons',
+            'test-color-icons',
+          ],
         }),
       ],
     }),

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
   "dependencies": {
     "@antfu/install-pkg": "^0.3.0",
     "@antfu/utils": "^0.7.6",
-    "@iconify/utils": "^2.1.12",
+    "@iconify/utils": "^2.1.20",
     "debug": "^4.3.4",
     "kolorist": "^1.8.0",
     "local-pkg": "^0.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.7.6
         version: 0.7.6
       '@iconify/utils':
-        specifier: ^2.1.12
-        version: 2.1.12
+        specifier: ^2.1.20
+        version: 2.1.20
       debug:
         specifier: ^4.3.4
         version: 4.3.4
@@ -127,7 +127,7 @@ importers:
         version: 2.2.110
       '@svgr/core':
         specifier: 8.1.0
-        version: 8.1.0
+        version: 8.1.0(typescript@5.2.2)
       '@svgr/plugin-jsx':
         specifier: ^8.1.0
         version: 8.1.0(@svgr/core@8.1.0)
@@ -3281,15 +3281,15 @@ packages:
   /@iconify/types@2.0.0:
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  /@iconify/utils@2.1.12:
-    resolution: {integrity: sha512-7vf3Uk6H7TKX4QMs2gbg5KR1X9J0NJzKSRNWhMZ+PWN92l0t6Q3tj2ZxLDG07rC3ppWBtTtA4FPmkQphuEmdsg==}
+  /@iconify/utils@2.1.20:
+    resolution: {integrity: sha512-t8TeKlYK/5i9yTY9VAGAE4P0qQHd/0vH+VSRO+bdpxlt8wqB6f2I0/IrciRsdeFZPMoL8IICgP7lgl2ZtbG8Tw==}
     dependencies:
       '@antfu/install-pkg': 0.1.1
       '@antfu/utils': 0.7.6
       '@iconify/types': 2.0.0
       debug: 4.3.4
       kolorist: 1.8.0
-      local-pkg: 0.4.3
+      local-pkg: 0.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -3872,15 +3872,6 @@ packages:
       - supports-color
     dev: true
 
-  /@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.22.8):
-    resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.22.8
-    dev: true
-
   /@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
     engines: {node: '>=14'}
@@ -3888,15 +3879,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-    dev: true
-
-  /@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.22.8):
-    resolution: {integrity: sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.22.8
     dev: true
 
   /@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.23.2):
@@ -3908,15 +3890,6 @@ packages:
       '@babel/core': 7.23.2
     dev: true
 
-  /@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.22.8):
-    resolution: {integrity: sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.22.8
-    dev: true
-
   /@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==}
     engines: {node: '>=14'}
@@ -3924,15 +3897,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-    dev: true
-
-  /@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.22.8):
-    resolution: {integrity: sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.22.8
     dev: true
 
   /@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.23.2):
@@ -3944,15 +3908,6 @@ packages:
       '@babel/core': 7.23.2
     dev: true
 
-  /@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.22.8):
-    resolution: {integrity: sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.22.8
-    dev: true
-
   /@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==}
     engines: {node: '>=14'}
@@ -3960,15 +3915,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-    dev: true
-
-  /@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.22.8):
-    resolution: {integrity: sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.22.8
     dev: true
 
   /@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.23.2):
@@ -3980,15 +3926,6 @@ packages:
       '@babel/core': 7.23.2
     dev: true
 
-  /@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.22.8):
-    resolution: {integrity: sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.22.8
-    dev: true
-
   /@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==}
     engines: {node: '>=14'}
@@ -3998,15 +3935,6 @@ packages:
       '@babel/core': 7.23.2
     dev: true
 
-  /@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.22.8):
-    resolution: {integrity: sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.22.8
-    dev: true
-
   /@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==}
     engines: {node: '>=12'}
@@ -4014,23 +3942,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-    dev: true
-
-  /@svgr/babel-preset@8.1.0(@babel/core@7.22.8):
-    resolution: {integrity: sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.22.8
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.22.8)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.22.8)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.22.8)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.22.8)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.22.8)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.22.8)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.22.8)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.22.8)
     dev: true
 
   /@svgr/babel-preset@8.1.0(@babel/core@7.23.2):
@@ -4048,19 +3959,6 @@ packages:
       '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.23.2)
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.23.2)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.23.2)
-    dev: true
-
-  /@svgr/core@8.1.0:
-    resolution: {integrity: sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@babel/core': 7.22.8
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.22.8)
-      camelcase: 6.3.0
-      cosmiconfig: 8.1.3
-      snake-case: 3.0.4
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@svgr/core@8.1.0(typescript@5.2.2):
@@ -4107,7 +4005,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.2
       '@svgr/babel-preset': 8.1.0(@babel/core@7.23.2)
-      '@svgr/core': 8.1.0
+      '@svgr/core': 8.1.0(typescript@5.2.2)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -6989,16 +6887,6 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
-    dev: true
-
-  /cosmiconfig@8.1.3:
-    resolution: {integrity: sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==}
-    engines: {node: '>=14'}
-    dependencies:
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      parse-json: 5.2.0
-      path-type: 4.0.0
     dev: true
 
   /cosmiconfig@8.3.6(typescript@5.2.2):
@@ -10223,6 +10111,7 @@ packages:
   /local-pkg@0.4.3:
     resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
     engines: {node: '>=14'}
+    dev: true
 
   /local-pkg@0.5.0:
     resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -1,7 +1,13 @@
 import type { Awaitable } from '@antfu/utils'
 import { FileSystemIconLoader as IconifyFileSystemIconLoader } from '@iconify/utils/lib/loader/node-loaders'
+import { createExternalPackageIconLoader } from '@iconify/utils/lib/loader/external-pkg'
+import type { AutoInstall, ExternalPkgName } from '@iconify/utils/lib/loader/types'
 import type { CustomIconLoader } from '.'
 
 export function FileSystemIconLoader(dir: string, transform?: (svg: string) => Awaitable<string>): CustomIconLoader {
   return IconifyFileSystemIconLoader(dir, transform)
+}
+
+export function ExternalPackageIconLoader(packageName: ExternalPkgName, autoInstall?: AutoInstall): Record<string, CustomIconLoader> {
+  return createExternalPackageIconLoader(packageName, autoInstall)
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
`@iconify/utils` from `v2.1.20` exposes a new `CustomIconLoader`  to allow load icons from custom external collection packages, this PR just adds the helper and the corresponding entry in the readme file.

@antfu should we  cleanup types and update TS to 5.3.3?

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
https://github.com/iconify/iconify/pull/276
