### PR TITLE
feat(vue3): allow passing components as props without reactivity overhead

### DIFF
--- a/src/core/compilers/vue3.ts
+++ b/src/core/compilers/vue3.ts
@@ -13,8 +13,11 @@ export const Vue3Compiler = (async (svg: string, collection: string, icon: strin
     filename: `${collection}-${icon}.vue`,
   })
 
+  code = `import { markRaw } from 'vue'\n${code}`
   code = code.replace(/^export /gm, '')
-  code += `\n\nexport default { name: '${collection}-${icon}', render${injectScripts ? `, data() {${injectScripts};return { idMap }}` : ''} }`
+  code += `\n\nexport default markRaw({ name: '${collection}-${icon}', render${
+    injectScripts ? `, data() {${injectScripts};return { idMap }}` : ''
+  } })`
   code += '\n/* vite-plugin-components disabled */'
 
   return code


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Currently if someone imports and passes a icon component as prop, Vue will track it deeply and will give warnings regarding associated performance overhead. This PR wraps the exported element with `markRaw` to disable deep tracking. 

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
