### PR TITLE
feat(react): enable ref option for SVGR in JSX compiler

### DIFF
--- a/src/core/compilers/jsx.ts
+++ b/src/core/compilers/jsx.ts
@@ -17,6 +17,7 @@ export const JSXCompiler = (async (
     svg,
     {
       plugins: ['@svgr/plugin-jsx'],
+      ref: options.jsx === 'react',
     },
     { componentName: camelize(`${collection}-${icon}`) },
   )

--- a/types/react.d.ts
+++ b/types/react.d.ts
@@ -1,14 +1,12 @@
 declare module 'virtual:icons/*' {
-  import type { SVGProps } from 'react'
-  import type React from 'react'
+  import type { ForwardRefExoticComponent, SVGProps } from 'react'
 
-  const component: (props: SVGProps<SVGSVGElement>) => React.ReactElement
+  const component: ForwardRefExoticComponent<SVGProps<SVGSVGElement>>
   export default component
 }
 declare module '~icons/*' {
-  import type { SVGProps } from 'react'
-  import type React from 'react'
+  import type { ForwardRefExoticComponent, SVGProps } from 'react'
 
-  const component: (props: SVGProps<SVGSVGElement>) => React.ReactElement
+  const component: ForwardRefExoticComponent<SVGProps<SVGSVGElement>>
   export default component
 }


### PR DESCRIPTION
### Description

In my project, I want to pass a ref to the generated React component, but it doesn't do anything and I get this error in the browser console:

> Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

This PR enables SVGR's [`ref` option](https://react-svgr.com/docs/options/#ref) if we are using React, which forwards ref to the root SVG tag.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
