### PR TITLE
chore: fix Next example configuration file

### DIFF
--- a/examples/next/next.config.js
+++ b/examples/next/next.config.js
@@ -3,7 +3,7 @@ module.exports = {
   reactStrictMode: true,
   webpack(config) {
     config.plugins.push(
-      require('unplugin-icons/webpack')({
+      require('unplugin-icons/webpack').default({
         compiler: 'jsx',
         jsx: 'react',
       }),


### PR DESCRIPTION
We need to use `.default` when registering webpack plugin

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR just updates the Next configuration file to use `.default` when registering the unplugin icons webpack plugin

### Linked Issues
NA

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Modified example https://stackblitz.com/edit/unplugin-unplugin-icons-xrvbve?file=next.config.js,pages%2Findex.tsx
