### PR TITLE
docs: updated README with note about Vue 3.12.13+ dropping requirement for `@vue/compiler-sfc` to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ See [the Astro + Vue example](examples/astro-vue) for a working example project.
 
 Vue 3 / Vue 2.7+ support requires peer dependency `@vue/compiler-sfc`:
 
-> Note that Vue 3.12.13+, this is no longer required as it is now included as a dependency of the main `vue` package.
+> Note that as of Vue 3.12.13+, this is no longer required as it is now included as a dependency of the main `vue` package.
 
 ```bash
 npm i -D @vue/compiler-sfc

--- a/README.md
+++ b/README.md
@@ -459,6 +459,8 @@ See [the Astro + Vue example](examples/astro-vue) for a working example project.
 
 Vue 3 / Vue 2.7+ support requires peer dependency `@vue/compiler-sfc`:
 
+> Note that Vue 3.12.13+, this is no longer required as it is now included as a dependency of the main `vue` package.
+
 ```bash
 npm i -D @vue/compiler-sfc
 ```


### PR DESCRIPTION
This is just a small documentation change to note that the `@vue/compiler-sfc` peer dependency is no longer required as of Vue 3.12.13, and is now included with the main vue package.