### PR TITLE
feat: support svelte snippets

### DIFF
--- a/src/core/compilers/svelte.ts
+++ b/src/core/compilers/svelte.ts
@@ -21,7 +21,7 @@ export const SvelteCompiler = (async (svg: string) => {
     sfc += `{@html \`${escapeSvelte(svg.slice(openTagEnd + 1, closeTagStart))}\`}`
 
   sfc += svg.slice(closeTagStart)
-  return svelteRunes ? `<script>const{...p}=$props()</script>${sfc}` : sfc
+  return svelteRunes ? `<script module>export{snippet}</script><script>const{...p}=$props()</script>{#snippet snippet(p)}${sfc}{/snippet}{@render snippet()}` : sfc
 }) as Compiler
 
 // escape curlies, backtick, \t, \r, \n to avoid breaking output of {@html `here`} in .svelte

--- a/types/svelte5.d.ts
+++ b/types/svelte5.d.ts
@@ -1,17 +1,21 @@
+import type { SvelteHTMLElements } from 'svelte/elements'
+
 declare module 'virtual:icons/*' {
-  import type { Component } from 'svelte'
-  import type { SvelteHTMLElements } from 'svelte/elements'
+  import type { Component, Snippet } from 'svelte'
 
   const component: Component<SvelteHTMLElements['svg']>
+  const snippet: Snippet<SvelteHTMLElements['svg']>
 
   export default component
+  export { snippet }
 }
 
 declare module '~icons/*' {
-  import type { Component } from 'svelte'
-  import type { SvelteHTMLElements } from 'svelte/elements'
+  import type { Component, Snippet } from 'svelte'
 
   const component: Component<SvelteHTMLElements['svg']>
+  const snippet: Snippet<SvelteHTMLElements['svg']>
 
   export default component
+  export { snippet }
 }


### PR DESCRIPTION
Hi  🧡
I was using Svelte 5 and I have a need to insert icnoks like [snippet](https://svelte.dev/docs/svelte/snippet) 🚀

### Description

I solved this by adding a snippet to the component generation and exporting the snippet from it

The old API is not broken, but now can be used additionally:
```svelte
<script>
  import Icon, { snippet: iconSnippet } from '~icons/collection/name'
</script>

<Icon color='red'/>

{@render iconSnippet({
  color: 'red' 
})}
```
I think this is a very nice improvement for those using svelte 5 with runes 🧡

I also updated the d.ts file. For reasons I don't understand, Snippet doesn't want to accept props from SvelteHTMLElements if it is imported inside a declare module. Because of this, I took it out of it 🥲

### Linked Issues

I hope this helps a lot of people 😍

### Additional context

Yes, please validate the d.ts file of svelte 5.
This is the only option that works for me 🧡
